### PR TITLE
feat: add project description

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -7,6 +7,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   authorOrganization: true,
   cdkVersion: '2.8.0',
   defaultReleaseBranch: 'main',
+  description: 'The CDK Construct Library that helps you build ECS services using simple extensions',
   name: 'cdklabs/cdk-ecs-service-extensions',
   repositoryUrl: 'https://github.com/cdklabs/cdk-ecs-service-extensions.git',
   stability: 'experimental',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@aws-cdk-containers/ecs-service-extensions",
+  "description": "The CDK Construct Library that helps you build ECS services using simple extensions",
   "repository": {
     "type": "git",
     "url": "https://github.com/cdklabs/cdk-ecs-service-extensions.git"


### PR DESCRIPTION
currently on [construct hub](https://constructs.dev/packages/@aws-cdk-containers/ecs-service-extensions/v/2.0.0?lang=typescript) it says there is 'no description available'. This PR should change that.