### PR TITLE
chore: revert "feat: add secrets and env files support"

### DIFF
--- a/src/extensions/container.ts
+++ b/src/extensions/container.ts
@@ -43,22 +43,6 @@ export interface ContainerExtensionProps {
   };
 
   /**
-   * The environment files to pass to the container.
-   *
-   * @see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/taskdef-envfiles.html
-   *
-   * @default - No environment files.
-   */
-  readonly environmentFiles?: ecs.EnvironmentFile[];
-
-  /**
-   * The secret environment variables to pass to the container.
-   *
-   * @default - No secret environment variables.
-   */
-  readonly secrets?: { [key: string]: ecs.Secret };
-
-  /**
    * The log group into which application container logs should be routed.
    *
    * @default - A log group is automatically created for you if the `ECS_SERVICE_EXTENSIONS_ENABLE_DEFAULT_LOG_DRIVER` feature flag is set.
@@ -116,8 +100,6 @@ export class Container extends ServiceExtension {
       cpu: Number(this.props.cpu),
       memoryLimitMiB: Number(this.props.memoryMiB),
       environment: this.props.environment,
-      environmentFiles: this.props.environmentFiles,
-      secrets: this.props.secrets,
     } as ecs.ContainerDefinitionOptions;
 
     // Let other extensions mutate the container definition. This is

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -5,7 +5,6 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as awslogs from 'aws-cdk-lib/aws-logs';
-import * as secrets from 'aws-cdk-lib/aws-secretsmanager';
 import * as cxapi from 'aws-cdk-lib/cx-api';
 import { Container, Environment, EnvironmentCapacityType, FireLensExtension, Service, ServiceDescription } from '../lib';
 
@@ -32,17 +31,12 @@ describe('container', () => {
     const taskRole = new iam.Role(stack, 'CustomTaskRole', {
       assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
     });
-    const secret = new secrets.Secret(stack, 'secret', {
-      secretName: 'secret',
-    });
+
     serviceDescription.add(new Container({
       cpu: 256,
       memoryMiB: 512,
       trafficPort: 80,
       image: ecs.ContainerImage.fromRegistry('nathanpeck/name'),
-      secrets: {
-        'my-secret': ecs.Secret.fromSecretsManager(secret),
-      },
     }));
 
     new Service(stack, 'my-service', {
@@ -73,14 +67,6 @@ describe('container', () => {
               HardLimit: 1024000,
               Name: 'nofile',
               SoftLimit: 1024000,
-            },
-          ],
-          Secrets: [
-            {
-              Name: 'my-secret',
-              ValueFrom: {
-                Ref: 'secret4DA88516',
-              },
             },
           ],
         },


### PR DESCRIPTION
Reverts cdklabs/cdk-ecs-service-extensions#86

The build was failing for this PR due to the tests added. This should not have been merged.