### PR TITLE
fix: adds an optional code path to create an HTTPs listener in HTTP LB extension

### DIFF
--- a/src/extensions/aliased-port.ts
+++ b/src/extensions/aliased-port.ts
@@ -1,8 +1,8 @@
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import { Construct } from 'constructs';
+import { Service } from '../service';
 import { Container } from './container';
 import { ContainerMutatingHook, ServiceBuild, ServiceExtension } from './extension-interfaces';
-import { Service } from '../service';
 
 
 /**

--- a/src/extensions/appmesh.ts
+++ b/src/extensions/appmesh.ts
@@ -6,9 +6,9 @@ import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as regionInfo from 'aws-cdk-lib/region-info';
 import { Construct } from 'constructs';
+import { ConnectToProps, Service } from '../service';
 import { Container } from './container';
 import { ServiceExtension, ServiceBuild } from './extension-interfaces';
-import { ConnectToProps, Service } from '../service';
 
 // The version of the App Mesh envoy sidecar to add to the task.
 const APP_MESH_ENVOY_SIDECAR_VERSION = 'v1.15.1.0-prod';

--- a/src/extensions/assign-public-ip/assign-public-ip.ts
+++ b/src/extensions/assign-public-ip/assign-public-ip.ts
@@ -2,10 +2,10 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import { Construct } from 'constructs';
-import { TaskRecordManager } from './task-record-manager';
 import { Service } from '../../service';
 import { Container } from '../container';
 import { ServiceExtension, ServiceBuild, EnvironmentCapacityType } from '../extension-interfaces';
+import { TaskRecordManager } from './task-record-manager';
 
 export interface AssignPublicIpExtensionOptions {
   /**

--- a/src/extensions/cloudwatch-agent.ts
+++ b/src/extensions/cloudwatch-agent.ts
@@ -1,8 +1,8 @@
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
-import { ServiceExtension } from './extension-interfaces';
 import { Service } from '../service';
+import { ServiceExtension } from './extension-interfaces';
 
 const CLOUDWATCH_AGENT_IMAGE = 'amazon/cloudwatch-agent:latest';
 

--- a/src/extensions/container.ts
+++ b/src/extensions/container.ts
@@ -2,8 +2,8 @@ import { RemovalPolicy } from 'aws-cdk-lib';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as awslogs from 'aws-cdk-lib/aws-logs';
 import * as cxapi from 'aws-cdk-lib/cx-api';
-import { ServiceExtension } from './extension-interfaces';
 import { Service } from '../service';
+import { ServiceExtension } from './extension-interfaces';
 
 // keep this import separate from other imports to reduce chance for merge conflicts with v2-main
 // eslint-disable-next-line no-duplicate-imports, import/order

--- a/src/extensions/firelens.ts
+++ b/src/extensions/firelens.ts
@@ -2,9 +2,9 @@ import { Stack, RemovalPolicy } from 'aws-cdk-lib';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as awslogs from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
+import { Service } from '../service';
 import { Container } from './container';
 import { ContainerMutatingHook, ServiceExtension } from './extension-interfaces';
-import { Service } from '../service';
 
 /**
  * Settings for the hook which mutates the application container

--- a/src/extensions/http-load-balancer.ts
+++ b/src/extensions/http-load-balancer.ts
@@ -1,15 +1,24 @@
 import { CfnOutput, Duration } from 'aws-cdk-lib';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as alb from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { Construct } from 'constructs';
-import { ServiceExtension, ServiceBuild } from './extension-interfaces';
 import { Service } from '../service';
+import { ServiceExtension, ServiceBuild } from './extension-interfaces';
 
 export interface HttpLoadBalancerProps {
   /**
    * The number of ALB requests per target.
    */
   readonly requestsPerTarget?: number;
+
+  /**
+   * An ACM certificate to associate with this load balancer. If specified, this
+   * extension will listen over HTTPS on port 443.
+   *
+   * @default - undefined. The load balancer will listen on port 80 over HTTP.
+   */
+  readonly certificate?: acm.ICertificate;
 }
 /**
  * This extension add a public facing load balancer for sending traffic
@@ -19,10 +28,12 @@ export class HttpLoadBalancerExtension extends ServiceExtension {
   private loadBalancer!: alb.IApplicationLoadBalancer;
   private listener!: alb.IApplicationListener;
   private requestsPerTarget?: number;
+  private certificate?: acm.ICertificate;
 
   constructor(props: HttpLoadBalancerProps = {}) {
     super('load-balancer');
     this.requestsPerTarget = props.requestsPerTarget;
+    this.certificate = props.certificate;
   }
 
   // Before the service is created, go ahead and create the load balancer itself.
@@ -33,11 +44,27 @@ export class HttpLoadBalancerExtension extends ServiceExtension {
       vpc: this.parentService.vpc,
       internetFacing: true,
     });
-
+    const protocol = this.certificate ? alb.ApplicationProtocol.HTTPS : alb.ApplicationProtocol.HTTP;
+    const port = this.certificate ? 443 : 80;
     this.listener = this.loadBalancer.addListener(`${this.parentService.id}-listener`, {
-      port: 80,
+      port,
+      protocol,
       open: true,
     });
+
+    if (this.certificate) {
+      this.listener.addCertificates('cert', [alb.ListenerCertificate.fromCertificateManager(this.certificate)]);
+      this.loadBalancer.addListener(`${this.parentService.id}-redirect-listener`, {
+        protocol: alb.ApplicationProtocol.HTTP,
+        port: 80,
+        open: true,
+        defaultAction: alb.ListenerAction.redirect({
+          port: '443',
+          protocol: alb.ApplicationProtocol.HTTPS,
+          permanent: true,
+        }),
+      });
+    }
 
     // Automatically create an output
     new CfnOutput(scope, `${this.parentService.id}-load-balancer-dns-output`, {

--- a/src/extensions/injecter.ts
+++ b/src/extensions/injecter.ts
@@ -1,9 +1,9 @@
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import { Construct } from 'constructs';
+import { Service } from '../service';
 import { Container } from './container';
 import { ContainerMutatingHook, ServiceExtension } from './extension-interfaces';
-import { Service } from '../service';
 
 /**
  * An interface that will be implemented by all the resources that can be published events or written data to.

--- a/src/extensions/xray.ts
+++ b/src/extensions/xray.ts
@@ -2,8 +2,8 @@ import { Duration, Stack } from 'aws-cdk-lib';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
-import { ServiceExtension } from './extension-interfaces';
 import { Service } from '../service';
+import { ServiceExtension } from './extension-interfaces';
 
 const XRAY_DAEMON_IMAGE = 'amazon/aws-xray-daemon:latest';
 


### PR DESCRIPTION
This allows customers experimenting with the library to add an existing ACM cert in order to create an HTTPs listener and redirect HTTP traffic to the secure endpoint.